### PR TITLE
[Bugfix] Skip headers when parsing csv

### DIFF
--- a/lib/airports.ex
+++ b/lib/airports.ex
@@ -7,7 +7,7 @@ defmodule Airports do
   @airports [__DIR__, "../priv", "airports.csv"]
             |> Path.join()
             |> File.stream!([], :line)
-            |> AirportsParser.parse_stream(skip_headers: false)
+            |> AirportsParser.parse_stream(skip_headers: true)
             |> Stream.map(fn line ->
               [
                 _,

--- a/test/airports_test.exs
+++ b/test/airports_test.exs
@@ -7,6 +7,8 @@ defmodule AirportsTest do
       |> Path.join()
       |> File.stream!([], :line)
       |> Enum.to_list()
+      # Remove header
+      |> List.delete_at(0)
       |> Enum.count()
 
     assert Enum.count(Airports.all()) == lines_count_from_source


### PR DESCRIPTION
Fix bug where headers are included when parsing the source CSV

Actual result:
```
iex(1)> Airports.all() |> List.first()
%Airports.Airport{
  continent: "continent",
  elevation_ft: "elevation_ft",
  gps_code: "gps_code",
  home_link: "home_link",
  iata_code: "iata_code",
  ident: "ident",
  iso_country: "iso_country",
  iso_region: "iso_region",
  keywords: "keywords",
  latitude: "latitude_deg",
  local_code: "local_code",
  longitude: "longitude_deg",
  municipality: "municipality",
  name: "name",
  scheduled_service: "scheduled_service",
  type: "type",
  wikipedia_link: "wikipedia_link"
}
```

Expected result:
```
iex(1)> Airports.all() |> List.first()
%Airports.Airport{
  continent: "NA",
  elevation_ft: "11",
  gps_code: "00A",
  home_link: "",
  iata_code: "",
  ident: "00A",
  iso_country: "US",
  iso_region: "US-PA",
  keywords: "",
  latitude: "40.07080078125",
  local_code: "00A",
  longitude: "-74.93360137939453",
  municipality: "Bensalem",
  name: "Total Rf Heliport",
  scheduled_service: "no",
  type: "heliport",
  wikipedia_link: ""
}
```